### PR TITLE
fix(ci): skip Docker build when DOCKERHUB_TOKEN is not set

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -19,6 +19,7 @@ concurrency: docker-build-plex-linker
 
 jobs:
   build:
+    if: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Makes the Docker build job conditional on secrets.DOCKERHUB_TOKEN so the workflow does not fail when repo secrets are not configured. Once DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are set in repo secrets, the job will run and push to Docker Hub.